### PR TITLE
add -codi switch so ihx be compatible with codi.vim

### DIFF
--- a/src/ihx/Set.hx
+++ b/src/ihx/Set.hx
@@ -22,7 +22,7 @@ abstract Set<T>(Array<T>) to Iterable<T>
 	public inline function iterator() return this.iterator();
 	public inline function join( sep ) return this.join( sep );
 
-	@:from public static function fromArray( a:Array<T> ) {
+	@:from public static function fromArray<T>( a:Array<T> ) {
 		var s = [];
 		for ( item in a ) {
 			if ( s.indexOf(item)==-1 ) s.push( item );


### PR DESCRIPTION
Codi is an interactive scratchpad for hackers.
https://github.com/metakirby5/codi.vim

Because of ihx way of continuously redrawing the prompted line it
couldn't work with codi. The hereafter modifications enable
(with `haxelib run ihx -codi`) a very simple alternative interpreter
that will enable codi to work with ihx.

Here is my configuration in .vimrc:
-------------------------------------
let g:codi#interpreters = {
    \ 'haxe': {
        \ 'bin': ['/home/xx/bin/ihx', '-codi'],
        \ 'prompt': '>> ',
        \ 'quitcmd': 'exit',
    \ },
\ }