### PR TITLE
Fix haxelib.json

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -9,6 +9,6 @@
   "version": "0.3.6",
   "url": "http://github.com/ianxm/ihx",
   "dependencies": {
-    "hx3compat"
+    "hx3compat": ""
   }
 }


### PR DESCRIPTION
A tiny syntax error in haxelib.json was making it impossible to import ihx types in other projects. Fixed it.