### PR TITLE
Fix partial command display

### DIFF
--- a/src/ihx/ConsoleReader.hx
+++ b/src/ihx/ConsoleReader.hx
@@ -146,6 +146,7 @@ class ConsoleReader
             }
             stdout.writeString(clearPrevCommand);
             stdout.writeString(cmd.toConsole());
+            stdout.flush();
         }
         return "";
     }


### PR DESCRIPTION
I'm so sorry--I feel like I'm spamming you with PRs today.

This one is a one-line fix for a bug I was having when running ConsoleReader in Haxe's `interp` target instead of Neko. The partial command would be invisible at the command line until I pressed Enter. This was because stdout wasn't being flushed, so without a newline to print, it wouldn't actually update.